### PR TITLE
Cache webhook avatars only for 1 day

### DIFF
--- a/webhooks.py
+++ b/webhooks.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from requests import Response
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, List
 
 import app
@@ -91,6 +91,12 @@ class Webhook:
         self.content = content
         self.username = username
         self.avatar_url = avatar_url
+        if type(avatar_url) == str:
+            # Prevent Discord caching avatars indefinetly, only cache for 1 day
+            now: datetime = datetime.now(timezone.utc)
+            epoch: datetime = datetime(1970, 1, 1, tzinfo=timezone.utc)
+            days_since_epoch = (now - epoch).days
+            self.avatar_url = f"{self.avatar_url}?t={days_since_epoch}"
         self.tts = is_tts
         self.file = file
         self.embeds = embeds


### PR DESCRIPTION
Discord will cache avatars indefinetly, so once an user views somebody's avatar in #events, it will never be updated. This pr adds a time query param to the avatar url that changed every day, so that Discord won't cache the avatar for any more than than.

Please test this change, I didn't test it (I can't log into my local instance). Also I'm not sure if it's the correct Pythonic way to do this, I'm not a Python developer.